### PR TITLE
FIX: No longer need to specify type arguments when using Matches.

### DIFF
--- a/Rhino.Mocks.Shared/Arg.cs
+++ b/Rhino.Mocks.Shared/Arg.cs
@@ -52,9 +52,9 @@ namespace Rhino.Mocks
 		/// demo.AssertWasCalled(x => x.Bar(Arg{string}.Matches(a => a.StartsWith("b") &amp;&amp; a.Contains("ba"))));
 		/// </code>
 		/// </example>
-		public static T Matches<TPredicate>(Predicate<TPredicate> predicate)
+		public static T Matches<T>(Predicate<T> predicate)
 		{
-			ArgManager.AddInArgument(Rhino.Mocks.Constraints.Is.Matching<TPredicate>(predicate));
+			ArgManager.AddInArgument(Rhino.Mocks.Constraints.Is.Matching<T>(predicate));
 			return default(T);
 		}
 #endif


### PR DESCRIPTION
Modified the type arguments on the Matches method so that it uses the type argument from the class.  This will let type inference do its thing and won't cause errors for users who are swapping to this to replace the old library.